### PR TITLE
[#4] 정류소 상세정보 화면 초기 구현

### DIFF
--- a/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/Bus.kt
+++ b/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/Bus.kt
@@ -1,0 +1,12 @@
+package com.chaeny.busoda.stopdetail
+
+internal data class Bus(
+    val busNumber: String,
+    val nextStopName: String,
+    val firstArrivalTime: String,
+    val firstPosition: String,
+    val firstCongestion: String,
+    val secondArrivalTime: String,
+    val secondPosition: String,
+    val secondCongestion: String
+)

--- a/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailAdapter.kt
+++ b/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailAdapter.kt
@@ -1,0 +1,50 @@
+package com.chaeny.busoda.stopdetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.chaeny.busoda.stopdetail.databinding.ListItemBusBinding
+
+internal class StopDetailAdapter : ListAdapter<Bus, StopDetailAdapter.BusDetailViewHolder>(BusDetailDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BusDetailViewHolder {
+        return BusDetailViewHolder(
+            ListItemBusBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: BusDetailViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class BusDetailViewHolder(private val binding: ListItemBusBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(busData: Bus) {
+            with(binding) {
+                textBusNumber.text = busData.busNumber
+                textNextStop.text = busData.nextStopName
+                textFirstArrivalTime.text = busData.firstArrivalTime
+                textFirstPosition.text = busData.firstPosition
+                textFirstCongestion.text = busData.firstCongestion
+                textSecondArrivalTime.text = busData.secondArrivalTime
+                textSecondPosition.text = busData.secondPosition
+                textSecondCongestion.text = busData.secondCongestion
+            }
+        }
+    }
+}
+
+private class BusDetailDiffCallback : DiffUtil.ItemCallback<Bus>() {
+    override fun areItemsTheSame(oldItem: Bus, newItem: Bus): Boolean {
+        return oldItem.busNumber == newItem.busNumber
+    }
+
+    override fun areContentsTheSame(oldItem: Bus, newItem: Bus): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailFragment.kt
+++ b/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailFragment.kt
@@ -17,12 +17,7 @@ class StopDetailFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentStopDetailBinding.inflate(inflater, container, false)
-        initDataReceiver()
         return binding.root
-    }
-
-    private fun initDataReceiver() {
-        binding.stopDetailTextView.text = arguments?.getString("data") ?: "No Data"
     }
 
 }

--- a/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailFragment.kt
+++ b/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailFragment.kt
@@ -17,7 +17,20 @@ class StopDetailFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentStopDetailBinding.inflate(inflater, container, false)
+        val adapter = StopDetailAdapter()
+        binding.busList.adapter = adapter
+        val dummyData = listOf(
+            Bus(
+                "604", "화곡본동시장", "2분 38초", "2번째 전", "보통",
+                "16분 18초", "9번째 전", "혼잡"),
+            Bus(
+                "5712", "화곡본동시장", "3분 38초", "3번째 전", "보통",
+                "17분 18초", "10번째 전", "혼잡"),
+            Bus(
+                "652", "화곡역1번출구", "4분 38초", "4번째 전", "보통",
+                "18분 18초", "11번째 전", "혼잡")
+        )
+        adapter.submitList(dummyData)
         return binding.root
     }
-
 }

--- a/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailFragment.kt
+++ b/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailFragment.kt
@@ -6,10 +6,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.chaeny.busoda.stopdetail.databinding.FragmentStopDetailBinding
+import androidx.fragment.app.viewModels
 
 class StopDetailFragment : Fragment() {
 
     private lateinit var binding: FragmentStopDetailBinding
+    private val viewModel: StopDetailViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -19,18 +21,13 @@ class StopDetailFragment : Fragment() {
         binding = FragmentStopDetailBinding.inflate(inflater, container, false)
         val adapter = StopDetailAdapter()
         binding.busList.adapter = adapter
-        val dummyData = listOf(
-            Bus(
-                "604", "화곡본동시장", "2분 38초", "2번째 전", "보통",
-                "16분 18초", "9번째 전", "혼잡"),
-            Bus(
-                "5712", "화곡본동시장", "3분 38초", "3번째 전", "보통",
-                "17분 18초", "10번째 전", "혼잡"),
-            Bus(
-                "652", "화곡역1번출구", "4분 38초", "4번째 전", "보통",
-                "18분 18초", "11번째 전", "혼잡")
-        )
-        adapter.submitList(dummyData)
+        subscribeUi(adapter)
         return binding.root
+    }
+
+    private fun subscribeUi(adapter: StopDetailAdapter) {
+        viewModel.busInfos.observe(viewLifecycleOwner) { buses ->
+            adapter.submitList(buses)
+        }
     }
 }

--- a/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailViewModel.kt
+++ b/feature/stopdetail/src/main/java/com/chaeny/busoda/stopdetail/StopDetailViewModel.kt
@@ -1,0 +1,31 @@
+package com.chaeny.busoda.stopdetail
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+internal class StopDetailViewModel : ViewModel() {
+
+    private val dummyData = MutableLiveData(
+        listOf(
+            Bus(
+                "604", "화곡본동시장", "2분 38초", "2번째 전", "보통",
+                "16분 18초", "9번째 전", "혼잡"
+            ),
+            Bus(
+                "5712", "화곡본동시장", "3분 38초", "3번째 전", "보통",
+                "17분 18초", "10번째 전", "혼잡"
+            ),
+            Bus(
+                "652", "화곡역1번출구", "4분 38초", "4번째 전", "보통",
+                "18분 18초", "11번째 전", "혼잡"
+            ),
+            Bus(
+                "강서01", "우체국", "3분 39초", "3번째 전", "여유",
+                "15분 14초", "11번째 전", "매우혼잡"
+            )
+        )
+    )
+
+    val busInfos: LiveData<List<Bus>> = dummyData
+}

--- a/feature/stopdetail/src/main/res/layout/fragment_stop_detail.xml
+++ b/feature/stopdetail/src/main/res/layout/fragment_stop_detail.xml
@@ -1,15 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".StopDetailFragment">
+    android:gravity="center"
+    android:orientation="vertical">
 
     <TextView
-        android:id="@+id/stop_detail_text_view"
-        android:layout_width="wrap_content"
+        android:id="@+id/text_bus_stop"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:textSize="50sp" />
+        android:layout_marginHorizontal="30dp"
+        android:layout_marginVertical="20dp"
+        android:gravity="center"
+        android:textColor="@android:color/black"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        tools:text="화곡역4번출구"
+        tools:textColor="@android:color/white" />
 
-</FrameLayout>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/bus_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/list_item_bus" />
+
+</LinearLayout>

--- a/feature/stopdetail/src/main/res/layout/list_item_bus.xml
+++ b/feature/stopdetail/src/main/res/layout/list_item_bus.xml
@@ -26,17 +26,31 @@
             android:textStyle="bold"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="604" />
+            tools:text="심야A21" />
 
         <TextView
             android:id="@+id/text_next_stop"
-            android:layout_width="wrap_content"
+            android:layout_width="200dp"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="5dp"
+            android:ellipsize="end"
+            android:gravity="right"
+            android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="15sp"
             app:layout_constraintBottom_toBottomOf="@id/text_bus_number"
-            app:layout_constraintEnd_toEndOf="parent"
-            tools:text="화곡본동시장 방면" />
+            app:layout_constraintEnd_toStartOf="@id/text_direction"
+            tools:text="강서구청사거리.서울디지털대학교" />
+
+        <TextView
+            android:id="@+id/text_direction"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/way"
+            android:textColor="@android:color/black"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="@id/text_bus_number"
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <TextView
             android:id="@+id/text_first_bus"

--- a/feature/stopdetail/src/main/res/layout/list_item_bus.xml
+++ b/feature/stopdetail/src/main/res/layout/list_item_bus.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="30dp"
+    android:layout_marginBottom="15dp"
+    app:cardBackgroundColor="@android:color/white"
+    app:cardCornerRadius="15dp"
+    app:cardElevation="1dp"
+    app:cardPreventCornerOverlap="false">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/text_bus_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="604" />
+
+        <TextView
+            android:id="@+id/text_next_stop"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="@id/text_bus_number"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="화곡본동시장 방면" />
+
+        <TextView
+            android:id="@+id/text_first_bus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:text="@string/first_bus"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_bus_number" />
+
+        <TextView
+            android:id="@+id/text_second_bus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/second_bus"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="@id/text_first_bus"
+            app:layout_constraintTop_toBottomOf="@id/text_first_bus" />
+
+        <TextView
+            android:id="@+id/text_first_arrival_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/text_first_bus"
+            app:layout_constraintStart_toEndOf="@id/text_first_bus"
+            tools:text="2분 38초 후" />
+
+        <TextView
+            android:id="@+id/text_first_position"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/text_first_bus"
+            app:layout_constraintStart_toEndOf="@id/text_first_arrival_time"
+            tools:text="1번째 전" />
+
+        <TextView
+            android:id="@+id/text_first_congestion"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/text_first_bus"
+            app:layout_constraintStart_toEndOf="@id/text_first_position"
+            tools:text="보통"
+            tools:textColor="@android:color/holo_green_dark" />
+
+        <TextView
+            android:id="@+id/text_second_arrival_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/text_second_bus"
+            app:layout_constraintStart_toStartOf="@id/text_first_arrival_time"
+            tools:text="16분 18초 후" />
+
+        <TextView
+            android:id="@+id/text_second_position"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/text_second_bus"
+            app:layout_constraintStart_toStartOf="@id/text_first_position"
+            tools:text="9번째 전" />
+
+        <TextView
+            android:id="@+id/text_second_congestion"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/text_second_bus"
+            app:layout_constraintStart_toStartOf="@id/text_first_congestion"
+            tools:text="혼잡"
+            tools:textColor="@android:color/holo_red_dark" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/feature/stopdetail/src/main/res/layout/list_item_bus.xml
+++ b/feature/stopdetail/src/main/res/layout/list_item_bus.xml
@@ -42,7 +42,7 @@
             android:id="@+id/text_first_bus"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
+            android:layout_marginStart="5dp"
             android:layout_marginTop="10dp"
             android:text="@string/first_bus"
             android:textColor="@android:color/black"
@@ -123,7 +123,7 @@
             android:textSize="14sp"
             app:layout_constraintBottom_toBottomOf="@id/text_second_bus"
             app:layout_constraintStart_toStartOf="@id/text_first_congestion"
-            tools:text="혼잡"
+            tools:text="매우혼잡"
             tools:textColor="@android:color/holo_red_dark" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/stopdetail/src/main/res/navigation/stopdetail_nav_graph.xml
+++ b/feature/stopdetail/src/main/res/navigation/stopdetail_nav_graph.xml
@@ -10,12 +10,7 @@
         android:name="com.chaeny.busoda.stopdetail.StopDetailFragment"
         tools:layout="@layout/fragment_stop_detail">
 
-        <deepLink
-            app:uri="android-app://com.chaeny.busoda/fragment_stop_detail?data={data}" />
-
-        <argument
-            android:name="data"
-            app:argType="string" />
+        <deepLink app:uri="android-app://com.chaeny.busoda/fragment_stop_detail" />
     </fragment>
 
 </navigation>

--- a/feature/stopdetail/src/main/res/values/strings.xml
+++ b/feature/stopdetail/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
-    <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="first_bus">첫번째 버스 :</string>
+    <string name="second_bus">두번째 버스 :</string>
 </resources>

--- a/feature/stopdetail/src/main/res/values/strings.xml
+++ b/feature/stopdetail/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="first_bus">첫번째 버스 :</string>
     <string name="second_bus">두번째 버스 :</string>
 </resources>

--- a/feature/stopdetail/src/main/res/values/strings.xml
+++ b/feature/stopdetail/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="first_bus">첫번째 버스 :</string>
     <string name="second_bus">두번째 버스 :</string>
+    <string name="way">방면</string>
 </resources>

--- a/feature/stoplist/src/main/java/com/chaeny/busoda/stoplist/StopListFragment.kt
+++ b/feature/stoplist/src/main/java/com/chaeny/busoda/stoplist/StopListFragment.kt
@@ -7,6 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.chaeny.busoda.stoplist.databinding.FragmentStopListBinding
+import androidx.core.net.toUri
+import androidx.navigation.NavDeepLinkRequest
+import androidx.navigation.fragment.findNavController
 
 class StopListFragment : Fragment() {
 
@@ -36,5 +39,17 @@ class StopListFragment : Fragment() {
         binding.removeStopButton.setOnClickListener {
             viewModel.removeLastStop()
         }
+
+        binding.moveStopButton.setOnClickListener {
+            navigateToStopDetail()
+        }
+    }
+
+    private fun navigateToStopDetail() {
+        val uri = "android-app://com.chaeny.busoda/fragment_stop_detail"
+        val request = NavDeepLinkRequest.Builder
+            .fromUri(uri.toUri())
+            .build()
+        findNavController().navigate(request)
     }
 }

--- a/feature/stoplist/src/main/res/layout/fragment_stop_list.xml
+++ b/feature/stoplist/src/main/res/layout/fragment_stop_list.xml
@@ -12,8 +12,19 @@
         android:id="@+id/remove_stop_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="30dp"
+        android:layout_marginHorizontal="30dp"
+        android:layout_marginTop="15dp"
         android:text="@string/remove_stop"
+        android:textColor="?attr/colorOnSecondary"
+        app:backgroundTint="@android:color/white" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/move_stop_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="30dp"
+        android:layout_marginVertical="15dp"
+        android:text="@string/move_stop"
         android:textColor="?attr/colorOnSecondary"
         app:backgroundTint="@android:color/white" />
 
@@ -21,6 +32,7 @@
         android:id="@+id/stop_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginTop="10dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listitem="@layout/list_item_stop" />
 

--- a/feature/stoplist/src/main/res/layout/list_item_stop.xml
+++ b/feature/stoplist/src/main/res/layout/list_item_stop.xml
@@ -21,6 +21,8 @@
             android:id="@+id/text_stop_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:paddingBottom="5dp"
             android:textColor="@android:color/black"
             android:textSize="18sp"
@@ -43,8 +45,11 @@
 
         <TextView
             android:id="@+id/text_next_stop"
-            android:layout_width="wrap_content"
+            android:layout_width="250dp"
             android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:gravity="right"
+            android:maxLines="1"
             android:textColor="@android:color/system_neutral1_600"
             android:textSize="14sp"
             app:layout_constraintEnd_toEndOf="parent"

--- a/feature/stoplist/src/main/res/values/strings.xml
+++ b/feature/stoplist/src/main/res/values/strings.xml
@@ -5,5 +5,6 @@
     <string name="stop_id">정류소ID</string>
     <string name="next_stop">다음정류소이름</string>
     <string name="remove_stop">정류소 지우기</string>
+    <string name="move_stop">정류소 상세 정보</string>
     <string name="direction">%1$s 방면</string>
 </resources>


### PR DESCRIPTION
### [정류소 상세정보 화면 초기 구현 #4 ](https://github.com/f-lab-edu/busoda/issues/4) 작업하였습니다.

✅ List Item 레이아웃 생성 (list_item_bus.xml)
✅ RecyclerView 추가
✅ StopDetailAdapter 추가
✅ stopDetailFragment에 더미 데이터를 추가하여 동작 검증
✅ StopListFragment에 StopDetailFragment로 이동할수 있는 버튼 추가
✅ ViewModel을 추가하여 더미 데이터 관리
✅ 텍스트 뷰가 길어질 경우 줄바꿈 제한 후 말줄임표 표시되도록 수정

### 💡 추가 구현 예정
- data layer쪽을 async하게 구성 (ex. 응답이 몇초 후에 오는걸 시뮬레이션)
- StopListFragment에서 정류소를 누르면 stopDetailFragment로 이동
