### PR TITLE
[#23] StopListViewModel의 LiveData 및 LiveEvent를 StateFlow와 SharedFlow로 마이그레이션

### DIFF
--- a/feature/stoplist/src/main/java/com/chaeny/busoda/stoplist/StopListFragment.kt
+++ b/feature/stoplist/src/main/java/com/chaeny/busoda/stoplist/StopListFragment.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -141,7 +142,7 @@ class StopListFragment : Fragment() {
     @Composable
     private fun StopListContent() {
         val stops by viewModel.busStops.observeAsState(initial = emptyList())
-        val isLoading by viewModel.isLoading.observeAsState(initial = false)
+        val isLoading by viewModel.isLoading.collectAsState(initial = false)
         StopList(stops, isLoading, onClickItem = { stopId -> viewModel.handleBusStopClick(stopId) })
     }
 

--- a/feature/stoplist/src/main/java/com/chaeny/busoda/stoplist/StopListViewModel.kt
+++ b/feature/stoplist/src/main/java/com/chaeny/busoda/stoplist/StopListViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
@@ -30,7 +31,7 @@ internal class StopListViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val _isLoading = MutableLiveData<Boolean>()
+    private val _isLoading = MutableStateFlow(false)
     private val _isNoResult = MutableLiveData<Event<Boolean>>()
     private val _isNoInternet = MutableLiveData<Event<Boolean>>()
     private val _isNetworkError = MutableLiveData<Event<Boolean>>()
@@ -38,7 +39,7 @@ internal class StopListViewModel @Inject constructor(
     private val _busStopClicked = MutableLiveData<Event<String>>()
     private val keyWord: MutableStateFlow<String> =
         MutableStateFlow(savedStateHandle.get(KEYWORD_SAVED_STATE_KEY) ?: EMPTY_KEYWORD)
-    val isLoading: LiveData<Boolean> = _isLoading
+    val isLoading: StateFlow<Boolean> = _isLoading
     val isNoResult: LiveData<Event<Boolean>> = _isNoResult
     val isNoInternet: LiveData<Event<Boolean>> = _isNoInternet
     val isNetworkError: LiveData<Event<Boolean>> = _isNetworkError


### PR DESCRIPTION
### [StopListViewModel의 LiveData/LiveEvent를 StateFlow/SharedFlow로 마이그레이션 #23](https://github.com/f-lab-edu/busoda/issues/23) 작업하였습니다.